### PR TITLE
Fix Handler() and invalidate(...) deprecation warnings

### DIFF
--- a/keyboardView/src/main/java/com/hijamoya/keyboardview/KeyboardView.java
+++ b/keyboardView/src/main/java/com/hijamoya/keyboardview/KeyboardView.java
@@ -46,6 +46,7 @@ import android.graphics.drawable.Drawable;
 import com.hijamoya.keyboardview.Keyboard.Key;
 
 import android.os.Handler;
+import android.os.Looper;
 import android.os.Message;
 import android.util.AttributeSet;
 import android.util.Log;
@@ -377,7 +378,7 @@ public class KeyboardView extends View implements View.OnClickListener {
         super.onAttachedToWindow();
         initGestureDetector();
         if (mHandler == null) {
-            mHandler = new Handler() {
+            mHandler = new Handler(Looper.getMainLooper()) {
                 @Override
                 public void handleMessage(Message msg) {
                     switch (msg.what) {
@@ -1033,8 +1034,7 @@ public class KeyboardView extends View implements View.OnClickListener {
         mDirtyRect.union(key.x + paddingLeft, key.y + paddingTop,
                 key.x + key.width + paddingLeft, key.y + key.height + paddingTop);
         onBufferDraw();
-        invalidate(key.x + paddingLeft, key.y + paddingTop,
-                key.x + key.width + paddingLeft, key.y + key.height + paddingTop);
+        invalidate();
     }
 
     private boolean openPopupIfRequired(MotionEvent me) {


### PR DESCRIPTION
This commit fixes the following two deprecation warnings:
1. `Handler() in Handler has been deprecated`
   Fixed by explicitly passing `Looper.getMainLooper()` as a parameter.
   See <https://stackoverflow.com/a/63851895>.
2. `invalidate(int,int,int,int) in View has been deprecated`
   From the documentation:
   > The switch to hardware accelerated rendering in API 14 reduced the
   > importance of the dirty rectangle. In API 21 the given rectangle is
   > ignored entirely in favor of an internally-calculated area instead.
   > Because of this, clients are encouraged to just call invalidate().